### PR TITLE
Use box-shadow instead of border-bottom to prevent layout jump

### DIFF
--- a/src/layouts/ArticleFooter.vue
+++ b/src/layouts/ArticleFooter.vue
@@ -108,7 +108,7 @@ const { frontmatter, theme } = useData();
 
     &:hover {
       transform: translateY(-0.3125rem);
-      border-bottom: 3px solid var(--color-accent);
+      box-shadow: 0 3px var(--color-accent);
       background-color: var(--color-background-second);
       max-width: 100%;
     }


### PR DESCRIPTION
Before/after.

[Screencast From 2024-09-25 07-11-09.webm](https://github.com/user-attachments/assets/62eef3af-af40-46b5-93d6-a63dc440aa9f)

[Screencast From 2024-09-25 07-10-52.webm](https://github.com/user-attachments/assets/e79bae0e-b9f6-41be-afdd-cf78ee127abd)